### PR TITLE
Fix critical typo in boundary trimming logic (Issue #50)

### DIFF
--- a/scripts/bond_scripts.py
+++ b/scripts/bond_scripts.py
@@ -10,7 +10,7 @@ def map_forces(geometry, force_output):
 
 	bond_atoms = []
 	for line in bond_forces:
-		bond_atoms.append(bond_forces[1])
+		bond_atoms.append(line[1])⁠
 	
 	#Use the base geometry and unoptimized dummy geometry to create a key
 	key = create_key(load_geometry(geometry), load_geometry(geometry[:-4] + "/" + os.path.splitext(force_output)[0] + ".xyz"), bond_atoms)


### PR DESCRIPTION
Fixes #50

**The Bug:**
In `scripts/bond_scripts.py`, a typo (`bond_atoms.append(bond_forces[1])` instead of `line[1]`) caused the internal list to populate with incorrect data types. This silently broke the boundary trimming logic, leading to the inclusion of artificial ghost strain in the final computed energies.

**The Fix:**
Corrected `bond_forces[1]` to `line[1]`.